### PR TITLE
bug fix for two PDBs and one GPU

### DIFF
--- a/comd.tcl
+++ b/comd.tcl
@@ -1607,8 +1607,13 @@ if { $argc < 3 } {
               lappend selection1 [lindex $gpus_selected $i]
               lappend selection2 [lindex $gpus_selected [expr {${i} + [llength $gpus_selected]/2 }]]
             }
-            set ::comd::gpus_selection1 [join $selection1 ","]
-            set ::comd::gpus_selection2 [join $selection2 ","]
+            if {$i > 0} {
+              set ::comd::gpus_selection1 [join $selection1 ","]
+              set ::comd::gpus_selection2 [join $selection2 ","]
+            } else {
+              set ::comd::gpus_selection1 $::comd::gpus_selected
+              set ::comd::gpus_selection2 $::comd::gpus_selected
+            }
           } else {
             set ::comd::gpus_selection1 $::comd::gpus_selected
             set ::comd::gpus_selection2 $::comd::gpus_selected


### PR DESCRIPTION
If there is only one GPU then it takes it from the original gpus_selected list rather than trying to join things from it.